### PR TITLE
doc: added steps for updating kernel manually in Jibri

### DIFF
--- a/docs/installingdep.md
+++ b/docs/installingdep.md
@@ -21,11 +21,11 @@ echo "snd-aloop">>/etc/modules
 modprobe snd-aloop
 ```
 
-**NOTE**: If you are running on AWS you may need to reboot your machine to use the generic kernel instead of the "aws" kernel. If after reboot, your machine is still using the "aws" kernel, you'll need to manually update the grub file. So just run:
+**NB**: If you are running on AWS you may need to reboot your machine to use the generic kernel instead of the "aws" kernel. If after reboot, your machine is still using the "aws" kernel, you'll need to manually update the grub file. So just run:
 
 ```bash
 # open the grub file in editor
-nano /etc/default/grub
+vim /etc/default/grub
 # Modify the value of GRUB_DEFAULT from "0" to "1>2"
 # Save and exit from file
 

--- a/docs/installingdep.md
+++ b/docs/installingdep.md
@@ -21,6 +21,20 @@ echo "snd-aloop">>/etc/modules
 modprobe snd-aloop
 ```
 
+**NOTE**: If you are running on AWS you may need to reboot your machine to use the generic kernel instead of the "aws" kernel. If after reboot, your machine is still using the "aws" kernel, you'll need to manually update the grub file. So just run:
+
+```bash
+# open the grub file in editor
+nano /etc/default/grub
+# Modify the value of GRUB_DEFAULT from "0" to "1>2"
+# Save and exit from file
+
+# Update grub
+update-grub
+# Reboot the machine
+reboot now
+```
+
 Install FFMPEG
 
 ```bash


### PR DESCRIPTION
I installed jibri on Ubuntu 18.04 on a spot instance. After installing the kernel and rebooting the instance, it was not able to detect the kernel required for jibri to work.

So I've added some additional steps which I followed to load the generic kernel instead of "aws" one.

Kindly have a look!